### PR TITLE
fix: make falwtydeps independent of provided paths

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
         name: "<<<CHECK>>> Secrets"
         verbose: true
   - repo: "https://github.com/google/osv-scanner/"
-    rev: "04a8728383d8f286cf2b0f110e68482e8773df6e"  # frozen: v2.2.1
+    rev: "16ed4529c0d0cc1ddf1bed2fb08deba187339673"  # frozen: v2.2.2
     hooks:
       - id: "osv-scanner"
         name: "<<<CHECK>>> OSV Scanner"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -881,13 +881,13 @@ tests-all = { composite = [
 ###############################################################################
 
 check-python = { composite = [
-  "fawltydeps --detailed --code {args:.}",
+  "fawltydeps --detailed",
   "ruff format --check {args:.}",
   "ruff check {args:.}",
   "interrogate {args:.}",
 ] }
 fix-python = { composite = [
-  "fawltydeps --detailed --code {args:.}",
+  "fawltydeps --detailed",
   "ruff format {args:.}",
   "ruff check --fix {args:.}",
   "interrogate {args:.}",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2025 open-nudge <https://github.com/open-nudge>
SPDX-FileContributor: szymonmaszke <github@maszke.co>

SPDX-License-Identifier: Apache-2.0
-->

<!--- pyml disable-next-line first-line-heading,first-line-h1-->

## Checklist

- [x] I agree to follow this project's [Code of Conduct](https://github.com/open-nudge/opentemplate/blob/main/CODE_OF_CONDUCT.md)
- [x] I have read this project's [Contributing Guide](https://github.com/open-nudge/opentemplate/blob/main/CONTRIBUTING.md)
- [x] I have created relevant issue(s) and linked them in the PR description

> Closes #76 
