### PR TITLE
fix: not display 'Additional info' by default

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,13 +9,19 @@ SPDX-License-Identifier: Apache-2.0
 
 ## Checklist
 
-- [ ] I agree to follow this project's [Code of Conduct](https://github.com/open-nudge/opentemplate/blob/main/CODE_OF_CONDUCT.md)
-- [ ] I have read this project's [Contributing Guide](https://github.com/open-nudge/opentemplate/blob/main/CONTRIBUTING.md)
-- [ ] I have created relevant issue(s) and linked them in the PR description
+- [] I agree to follow this project's [Code of Conduct](https://github.com/open-nudge/opentemplate/blob/main/CODE_OF_CONDUCT.md)
+- [] I have read this project's [Contributing Guide](https://github.com/open-nudge/opentemplate/blob/main/CONTRIBUTING.md)
+- [] I have created relevant issue(s) and linked them in the PR description
+
+<!-- Issue number this PR resolves -->
 
 > Closes #
 
-## Additional information
+<!-- ## Additional information -->
 
-Provide any additional information that may be relevant and
-was not covered by the issue description (mainly technical) below:
+<!--
+Provide any additional information that may be relevant and were
+not covered by the issue description.
+
+Usually you would include technical details, implementation choices and so on.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,7 +20,7 @@ SPDX-License-Identifier: Apache-2.0
 <!-- ## Additional information -->
 
 <!--
-Provide any additional information that may be relevant and were
+Provide any additional information that may be relevant and was
 not covered by the issue description.
 
 Usually you would include technical details, implementation choices and so on.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2025 open-nudge <https://github.com/open-nudge>
SPDX-FileContributor: szymonmaszke <github@maszke.co>

SPDX-License-Identifier: Apache-2.0
-->

<!--- pyml disable-next-line first-line-heading,first-line-h1-->

## Checklist

- [x] I agree to follow this project's [Code of Conduct](https://github.com/open-nudge/opentemplate/blob/main/CODE_OF_CONDUCT.md)
- [x] I have read this project's [Contributing Guide](https://github.com/open-nudge/opentemplate/blob/main/CONTRIBUTING.md)
- [x] I have created relevant issue(s) and linked them in the PR description

> Closes #86 
