### PR TITLE
fix: upload workflow permissions

### DIFF
--- a/.github/workflows/release-sboms-test.yml
+++ b/.github/workflows/release-sboms-test.yml
@@ -42,6 +42,8 @@ jobs:
   release-sboms-test:
     name: "Release SBOMs Test"
     permissions:
+      actions: "read" # https://github.com/github/codeql-action/issues/2117
+      security-events: "write" # Needed to upload SARIF file to tab
       id-token: "write" # Needed to get GH Token to attest
       attestations: "write" # Needed to upload attestation
       contents: "read"

--- a/.github/workflows/security-sbom-github-update.yml
+++ b/.github/workflows/security-sbom-github-update.yml
@@ -19,6 +19,8 @@ jobs:
       actions: "read" # https://github.com/github/codeql-action/issues/2117
       security-events: "write" # Needed to upload SARIF file to tab
       contents: "read"
+      id-token: "write" # Needed to get GH Token to attest
+      attestations: "write" # Needed to upload attestation
     name: "Security SBOM GitHub Update"
     # enq: hash with name and version always longer than 80 chars
     # yamllint disable rule:line-length

--- a/.github/workflows/security-sbom-github.yml
+++ b/.github/workflows/security-sbom-github.yml
@@ -24,7 +24,11 @@ concurrency:
 jobs:
   security-sbom-github:
     permissions:
+      actions: "read" # https://github.com/github/codeql-action/issues/2117
+      security-events: "write" # Needed to upload SARIF file to tab
       contents: "read"
+      id-token: "write" # Needed to get GH Token to attest
+      attestations: "write" # Needed to upload attestation
     name: "Security SBOM GitHub"
     # enq: hash with name and version always longer than 80 chars
     # yamllint disable rule:line-length

--- a/.github/workflows/security-sbom-legal-update.yml
+++ b/.github/workflows/security-sbom-legal-update.yml
@@ -30,6 +30,8 @@ jobs:
       actions: "read" # https://github.com/github/codeql-action/issues/2117
       security-events: "write" # Needed to upload SARIF file to tab
       contents: "read"
+      id-token: "write" # Needed to get GH Token to attest
+      attestations: "write" # Needed to upload attestation
     name: "Security SBOM Legal Update"
     # enq: hash with name and version always longer than 80 chars
     # yamllint disable rule:line-length

--- a/.github/workflows/security-sbom-legal.yml
+++ b/.github/workflows/security-sbom-legal.yml
@@ -24,7 +24,11 @@ concurrency:
 jobs:
   security-sbom-legal:
     permissions:
+      actions: "read" # https://github.com/github/codeql-action/issues/2117
+      security-events: "write" # Needed to upload SARIF file to tab
       contents: "read"
+      id-token: "write" # Needed to get GH Token to attest
+      attestations: "write" # Needed to upload attestation
     name: "Security SBOM Legal"
     # enq: hash with name and version always longer than 80 chars
     # yamllint disable rule:line-length

--- a/.github/workflows/security-sbom-python-update.yml
+++ b/.github/workflows/security-sbom-python-update.yml
@@ -30,6 +30,8 @@ jobs:
       actions: "read" # https://github.com/github/codeql-action/issues/2117
       security-events: "write" # Needed to upload SARIF file to tab
       contents: "read"
+      id-token: "write" # Needed to get GH Token to attest
+      attestations: "write" # Needed to upload attestation
     name: "Security SBOM Python Update"
     # enq: hash with name and version always longer than 80 chars
     # yamllint disable rule:line-length

--- a/.github/workflows/security-sbom-python.yml
+++ b/.github/workflows/security-sbom-python.yml
@@ -24,7 +24,11 @@ concurrency:
 jobs:
   security-sbom-python:
     permissions:
+      actions: "read" # https://github.com/github/codeql-action/issues/2117
+      security-events: "write" # Needed to upload SARIF file to tab
       contents: "read"
+      id-token: "write" # Needed to get GH Token to attest
+      attestations: "write" # Needed to upload attestation
     name: "Security SBOM Python"
     # enq: hash with name and version always longer than 80 chars
     # yamllint disable rule:line-length


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2025 open-nudge <https://github.com/open-nudge>
SPDX-FileContributor: szymonmaszke <github@maszke.co>

SPDX-License-Identifier: Apache-2.0
-->

<!--- pyml disable-next-line first-line-heading,first-line-h1 -->

## Checklist

- [x] I agree to follow this project's [Code of Conduct](https://github.com/open-nudge/opentemplate/blob/main/CODE_OF_CONDUCT.md)
- [x] I have read this project's [Contributing Guide](https://github.com/open-nudge/opentemplate/blob/main/CONTRIBUTING.md)
- [x] I have created relevant issue(s) and linked them in the PR description

<!-- Issue number this PR resolves -->

> Closes #106 

<!-- ## Additional information -->

<!--
Provide any additional information that may be relevant and was
not covered by the issue description.

Usually you would include technical details, implementation choices and so on.
-->
