### PR TITLE
fix: correctly parse version for changelog

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,14 @@ jobs:
       # yamllint disable rule:line-length
       command: |
         mkdir -p CHANGELOGS-${{ github.sha }}
-        export PYTHON_PACKAGE_VERSION=$(basename dist-${{ github.sha }}/dist/*.tar.gz | cut -d '-' -f 2)
+        shopt -s nullglob
+        sdists=(*.tar.gz)
+        if (( ${#sdists[@]} != 1 )); then
+        echo "::error title=Invalid source distribution artifacts::Expected exactly one *.tar.gz file, found ${#sdists[@]}."
+        exit 1
+        fi
+        sdist_name=${sdists[0]%.tar.gz}
+        export PYTHON_PACKAGE_VERSION=${sdist_name#*-}
         pdm run changelog > CHANGELOGS-${{ github.sha }}/CHANGELOG-${{ github.sha }}.md
         pdm run changelog-latest > CHANGELOGS-${{ github.sha }}/LATEST.md
       # yamllint enable rule:line-length


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: © 2025 open-nudge <https://github.com/open-nudge>
SPDX-FileContributor: szymonmaszke <github@maszke.co>

SPDX-License-Identifier: Apache-2.0
-->

<!--- pyml disable-next-line first-line-heading,first-line-h1 -->

## Checklist

- [] I agree to follow this project's [Code of Conduct](https://github.com/open-nudge/opentemplate/blob/main/CODE_OF_CONDUCT.md)
- [] I have read this project's [Contributing Guide](https://github.com/open-nudge/opentemplate/blob/main/CONTRIBUTING.md)
- [] I have created relevant issue(s) and linked them in the PR description

<!-- Issue number this PR resolves -->

> Closes #148 
